### PR TITLE
Added GitHub Actions

### DIFF
--- a/.github/workflows/PushPullTesting.yml
+++ b/.github/workflows/PushPullTesting.yml
@@ -1,0 +1,49 @@
+name: Go CI
+
+on:
+  push:
+    branches: [ main, feature ]
+  pull_request:
+    branches: [ main, feature ]
+
+jobs:
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Git repo for lint
+        uses: actions/checkout@v4
+
+      - name: Set up Go for lint
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.19
+          cache: false
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+
+
+  build:
+    needs: golangci 
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Git repo for build and test
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+          go-version: 1.19
+
+    - name: Build Client
+      run: go build -v ./client-go/...
+
+    - name: Build Service
+      run: go build -v ./service-go/...
+
+    - name: Test Greeter
+      run: go test -v ./service-go/internal/domain/greeter/...

--- a/.github/workflows/PushPullTesting.yml
+++ b/.github/workflows/PushPullTesting.yml
@@ -8,34 +8,11 @@ on:
 
 jobs:
 
-  golangci:
-    name: lint
-    runs-on: ubuntu-latest
 
-    steps:
-      - name: Set up Git repo for lint
-        uses: actions/checkout@v4
-
-      - name: Set up Go for lint
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.19
-          cache: false
-
-      - name: golangci-lint on client
-        uses: golangci/golangci-lint-action@v4
-        with:
-          working-directory: client-go
-
-      - name: golangci-lint on service
-        uses: golangci/golangci-lint-action@v4
-        with:
-          working-directory: service-go
 
 
 
   build:
-    needs: golangci 
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/PushPullTesting.yml
+++ b/.github/workflows/PushPullTesting.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
 
-  
-
   build:
     
     runs-on: ubuntu-latest

--- a/.github/workflows/PushPullTesting.yml
+++ b/.github/workflows/PushPullTesting.yml
@@ -54,10 +54,7 @@ jobs:
         echo "${{ github.workspace }}/go/bin" >> $GITHUB_PATH
 
     - name: Compile Protos
-      run: |
-        protoc --go_out=. --go_opt=paths=source_relative \
-        --go-grpc_out=. --go-grpc_opt=paths=source_relative \
-        -I./gen ./gen/proto/interview/*.proto
+      run: ./gen/proto/generate.sh
 
     - name: Build Client
       run: go build -v ./client-go/...

--- a/.github/workflows/PushPullTesting.yml
+++ b/.github/workflows/PushPullTesting.yml
@@ -22,8 +22,16 @@ jobs:
           go-version: 1.19
           cache: false
 
-      - name: golangci-lint
+      - name: golangci-lint on client
         uses: golangci/golangci-lint-action@v4
+        with:
+          working-directory: client-go
+
+      - name: golangci-lint on service
+        uses: golangci/golangci-lint-action@v4
+        with:
+          working-directory: service-go
+
 
 
   build:
@@ -38,6 +46,20 @@ jobs:
       uses: actions/setup-go@v5
       with:
           go-version: 1.19
+    
+    - name: Install ProtoBuf compiler
+      run: |
+        sudo apt update
+        sudo apt install -y protobuf-compiler
+        go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+        go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+        echo "${{ github.workspace }}/go/bin" >> $GITHUB_PATH
+
+    - name: Compile Protos
+      run: |
+        protoc --go_out=. --go_opt=paths=source_relative \
+        --go-grpc_out=. --go-grpc_opt=paths=source_relative \
+        -I./gen ./gen/*.proto
 
     - name: Build Client
       run: go build -v ./client-go/...

--- a/.github/workflows/PushPullTesting.yml
+++ b/.github/workflows/PushPullTesting.yml
@@ -8,32 +8,10 @@ on:
 
 jobs:
 
-  golangci:
-    name: lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set up Git repo for lint
-        uses: actions/checkout@v4
-
-      - name: Set up Go for lint
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.19
-          cache: false
-
-      - name: golangci-lint on client
-        uses: golangci/golangci-lint-action@v4
-        with:
-          working-directory: client-go
-
-      - name: golangci-lint on service
-        uses: golangci/golangci-lint-action@v4
-        with:
-          working-directory: service-go
+  
 
   build:
-    needs: golangci 
+    
     runs-on: ubuntu-latest
 
     steps:
@@ -64,3 +42,28 @@ jobs:
 
     - name: Test Greeter
       run: go test -v ./service-go/internal/domain/greeter/...
+
+  golangci:
+    needs: build 
+    name: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Git repo for lint
+        uses: actions/checkout@v4
+
+      - name: Set up Go for lint
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.19
+          cache: false
+
+      - name: golangci-lint on client
+        uses: golangci/golangci-lint-action@v4
+        with:
+          working-directory: client-go
+
+      - name: golangci-lint on service
+        uses: golangci/golangci-lint-action@v4
+        with:
+          working-directory: service-go

--- a/.github/workflows/PushPullTesting.yml
+++ b/.github/workflows/PushPullTesting.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Test Greeter
       run: go test -v ./service-go/internal/domain/greeter/...
 
+    - name: Integration test Hello World
+      run: go test -v ./client-go/internal/consumer/...
+
   golangci:
     needs: build 
     name: lint
@@ -57,6 +60,17 @@ jobs:
         with:
           go-version: 1.19
           cache: false
+
+      - name: Install ProtoBuf compiler
+        run: |
+          sudo apt update
+          sudo apt install -y protobuf-compiler
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          echo "${{ github.workspace }}/go/bin" >> $GITHUB_PATH
+
+      - name: Compile Protos
+        run: ./setup.sh
 
       - name: golangci-lint on client
         uses: golangci/golangci-lint-action@v4

--- a/.github/workflows/PushPullTesting.yml
+++ b/.github/workflows/PushPullTesting.yml
@@ -9,10 +9,8 @@ on:
 jobs:
 
 
-
-
-
   build:
+  
     runs-on: ubuntu-latest
 
     steps:
@@ -36,7 +34,7 @@ jobs:
       run: |
         protoc --go_out=. --go_opt=paths=source_relative \
         --go-grpc_out=. --go-grpc_opt=paths=source_relative \
-        -I./gen ./gen/*.proto
+        -I./gen ./gen/proto/interview/*.proto
 
     - name: Build Client
       run: go build -v ./client-go/...

--- a/.github/workflows/PushPullTesting.yml
+++ b/.github/workflows/PushPullTesting.yml
@@ -32,7 +32,7 @@ jobs:
         echo "${{ github.workspace }}/go/bin" >> $GITHUB_PATH
 
     - name: Compile Protos
-      run: ./gen/proto/generate.sh
+      run: ./setup.sh
 
     - name: Build Client
       run: go build -v ./client-go/...

--- a/.github/workflows/PushPullTesting.yml
+++ b/.github/workflows/PushPullTesting.yml
@@ -8,9 +8,32 @@ on:
 
 jobs:
 
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Git repo for lint
+        uses: actions/checkout@v4
+
+      - name: Set up Go for lint
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.19
+          cache: false
+
+      - name: golangci-lint on client
+        uses: golangci/golangci-lint-action@v4
+        with:
+          working-directory: client-go
+
+      - name: golangci-lint on service
+        uses: golangci/golangci-lint-action@v4
+        with:
+          working-directory: service-go
 
   build:
-  
+    needs: golangci 
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/SecScan.yml
+++ b/.github/workflows/SecScan.yml
@@ -1,0 +1,27 @@
+name: Security Scan
+
+on:
+    push:
+        branches: [ main, feature ]
+    pull_request:
+        branches: [ main, feature ]
+    
+jobs:
+    security-scan:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repo branch
+              uses: actions/checkout@v4
+            
+            - name: Install Nmap
+              run: sudo apt-get install -y nmap
+
+            - name: Run and save Nmap scan
+              run: nmap -v -sV localhost > nmap-results.txt
+
+            - name: Upload Results
+              uses: actions/upload-artifact@v3
+              with:
+                name: nmap-results
+                path: nmap-results.txt
+

--- a/.github/workflows/SecScan.yml
+++ b/.github/workflows/SecScan.yml
@@ -20,7 +20,7 @@ jobs:
               run: nmap -v -sV localhost > nmap-results.txt
 
             - name: Upload Results
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: nmap-results
                 path: nmap-results.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 .vsode
 *.idea
 *pb.go
-
-client
-service

--- a/client-go/cmd/client/Sim-Fornt-End_test.go
+++ b/client-go/cmd/client/Sim-Fornt-End_test.go
@@ -1,0 +1,59 @@
+package main_test
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+
+	"interview-client/internal/consumer"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type config struct {
+	Server string `json:"Server"`
+}
+
+func loadConfig() (c config) {
+	f, err := os.Open("./configs/local.json")
+	defer f.Close()
+	if err != nil {
+		log.Fatalln("failed to open config file: ", err)
+	}
+
+	decoder := json.NewDecoder(f)
+	err = decoder.Decode(&c)
+	if err != nil {
+		log.Fatalln("failed to decode config file: ", err)
+	}
+
+	return c
+}
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	conn, err := setupTestConnection(ctx)
+	if err != nil {
+		log.Fatalln("failed to connect to test service:", err)
+	}
+	defer conn.Close()
+
+	consumer.New(conn)
+
+	os.Exit(m.Run())
+}
+
+// TODO add JWT auth so that the client can properly run without issues in the unary interceptor.
+func setupTestConnection(ctx context.Context) (*grpc.ClientConn, error) {
+	config := loadConfig()
+
+	return grpc.DialContext(
+		ctx,
+		config.Server,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+}

--- a/client-go/cmd/client/client.go
+++ b/client-go/cmd/client/client.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os"
 
+	"interview-client/internal/api/interview"
+
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -49,5 +51,8 @@ func main() {
 
 	consumer := consumer.New(conn)
 
-	consumer.HelloWorld(ctx)
+	//blank req just to run w/o crashes
+	request := &interview.HelloWorldRequest{Name: ""}
+
+	consumer.HelloWorld(ctx, request)
 }

--- a/client-go/internal/consumer/consumer_test.go
+++ b/client-go/internal/consumer/consumer_test.go
@@ -17,7 +17,7 @@ type testCase struct {
 
 // TestHelloWorld uses a table-driven test to check the behavior of the HelloWorld function.
 func TestHelloWorld(t *testing.T) {
-	c := consumer.GetConsumer() // This assumes that you have a method to get the consumer instance.
+	c := consumer.GetConsumer()
 
 	tests := []testCase{
 		{

--- a/client-go/internal/consumer/consumer_test.go
+++ b/client-go/internal/consumer/consumer_test.go
@@ -1,0 +1,48 @@
+package consumer_test
+
+import (
+	"context"
+	"testing"
+
+	"interview-client/internal/api/interview"
+	"interview-client/internal/consumer"
+)
+
+type testCase struct {
+	name         string
+	request      *interview.HelloWorldRequest
+	expectedResp *interview.HelloWorldResponse
+	expectedErr  error
+}
+
+// TestHelloWorld uses a table-driven test to check the behavior of the HelloWorld function.
+func TestHelloWorld(t *testing.T) {
+	c := consumer.GetConsumer() // This assumes that you have a method to get the consumer instance.
+
+	tests := []testCase{
+		{
+			name:         "Empty Request",
+			request:      &interview.HelloWorldRequest{Name: ""},
+			expectedResp: &interview.HelloWorldResponse{Greeting: "Hello, World!"},
+			expectedErr:  nil,
+		},
+		{
+			name:         "Non-Empty Request",
+			request:      &interview.HelloWorldRequest{Name: "Alice"},
+			expectedResp: &interview.HelloWorldResponse{Greeting: "Hello, Alice!"},
+			expectedErr:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := c.HelloWorld(context.Background(), tc.request)
+			if err != tc.expectedErr {
+				t.Errorf("Test %s failed: expected error %v, got %v", tc.name, tc.expectedErr, err)
+			}
+			if err == nil && resp.GetGreeting() != tc.expectedResp.GetGreeting() {
+				t.Errorf("Test %s failed: expected response %v, got %v", tc.name, tc.expectedResp.GetGreeting(), resp.GetGreeting())
+			}
+		})
+	}
+}

--- a/gen/proto/generate.sh
+++ b/gen/proto/generate.sh
@@ -1,21 +1,33 @@
 #!/bin/bash
 
-SERVICE_RELATIVE_PATH="../../service-go/internal/api"
+# Base directory is the current directory where the script is run
+BASE_DIR=$(pwd)
 
-mkdir -p $SERVICE_RELATIVE_PATH
+# Directories for generated code relative to gen/proto
+SERVICE_TARGET_DIR="$BASE_DIR/../../service-go/internal/api/interview"
+CLIENT_TARGET_DIR="$BASE_DIR/../../client-go/internal/api/interview"
 
-protoc --go_out=$SERVICE_RELATIVE_PATH --go_opt=paths=source_relative \
-    --go-grpc_out=$SERVICE_RELATIVE_PATH --go-grpc_opt=paths=source_relative \
-    interview/interview.proto
+# Create target directories if they do not exist
+mkdir -p "$SERVICE_TARGET_DIR"
+mkdir -p "$CLIENT_TARGET_DIR"
+
+# Directory where the .proto files are located
+PROTO_SOURCE_DIR="$BASE_DIR/interview"
+
+# Generate the protocol buffers and gRPC stubs for service-go
+echo "📁 Generating protocol buffers and gRPC stubs for service-go..."
+protoc --proto_path="$PROTO_SOURCE_DIR" \
+       --go_out="$SERVICE_TARGET_DIR" --go_opt=paths=source_relative \
+       --go-grpc_out="$SERVICE_TARGET_DIR" --go-grpc_opt=paths=source_relative \
+       "$PROTO_SOURCE_DIR"/interview.proto
 
 echo "✅ Compiled proto stubs for service-go"
 
-CLIENT_RELVATIVE_PATH="../../client-go/internal/api"
-
-mkdir -p $CLIENT_RELVATIVE_PATH
-
-protoc --go_out=$CLIENT_RELVATIVE_PATH --go_opt=paths=source_relative \
-    --go-grpc_out=$CLIENT_RELVATIVE_PATH --go-grpc_opt=paths=source_relative \
-    interview/interview.proto
+# Generate the protocol buffers and gRPC stubs for client-go
+echo "📁 Generating protocol buffers and gRPC stubs for client-go..."
+protoc --proto_path="$PROTO_SOURCE_DIR" \
+       --go_out="$CLIENT_TARGET_DIR" --go_opt=paths=source_relative \
+       --go-grpc_out="$CLIENT_TARGET_DIR" --go-grpc_opt=paths=source_relative \
+       "$PROTO_SOURCE_DIR"/interview.proto
 
 echo "✅ Compiled proto stubs for client-go"

--- a/service-go/cmd/service/service.go
+++ b/service-go/cmd/service/service.go
@@ -55,7 +55,7 @@ func main() {
 
 const (
 	authHeader = "authorization"
-	configPath = "./config/grpc.json"
+	configPath = "../config/grpc.json"
 )
 
 // validateJWT parses and validates a bearer jwt


### PR DESCRIPTION
Next Steps: added a simple integration test client that sets up a grpc connection the backend service provider and then tests the connection via helloworld function in the consumer. runs two test one for empty values, and one with a string for a name. final next steps would be to fix the service so that JWT tokens is present, and run the service so the test can run.

Fixed: Currently the generate proto script in the gen/proto directory does not work in the GitHub runner virtual environment. The next step would be to fix the script to run both in the runner and locally on dev machines and test that the code compiles correctly in the build step of the workflow.

This PR adds two workflows for GitHub Actions. Both workflows are set to run on code pushes and PRs for the main branch, and another branch, called "feature", that was used to test this feature. The first job in the workflow runs Golangci-lint (I could not find an action for gopls). The second job attempts to build the code and run the unit tests attached in the /service-go/internal/domain/greeter/ directory. The second workflow runs a nmap scan of the runner on which the workflow is run to find open ports and creates a build artifact that can be saved for later. If any of the steps in either workflow fails during a pull request the PR will be labeled with what exactly failed and a detailed description, and the repo owner will receive an email that the action failed. 

Disclaimer: This will block development on the interview project if this PR is completed until these packages are implemented:
"interview-client/internal/api/interview"
"interview-service/internal/api/interview"